### PR TITLE
Switch group validation to invitation links

### DIFF
--- a/SEbased/config.json
+++ b/SEbased/config.json
@@ -17,6 +17,12 @@
         "message_content": "span.text",
         "message_time": "span.card-send-time__sendTime",
         "chat_input": "div#richInput",
+        "message_icon": "i.fa.fa-Message_28_Filled.internal-icon",
+        "contact_icon": "i.fa.fa-Contact_28_Line.internal-icon",
+        "community_icon": "i.fa.fa-Community_List_24_Line.menu__icon",
+        "group_list_items": "div.contact-item-v2-wrapper span.name",
+        "group_avatar": "div#ava_chat_box_view",
+        "invitation_link": "div.pi-group-profile-link__link",
         "unread_notif_icons": [
             "i.fa.fa-1_24_Line.z-noti-badge__content.--big",
             "i.fa.fa-2_24_Line.z-noti-badge__content.--big",

--- a/SEbased/run_app.py
+++ b/SEbased/run_app.py
@@ -6,7 +6,6 @@ import re
 import sys
 import threading
 import time
-import uuid
 from queue import Queue, Empty
 from datetime import datetime, timedelta, timezone
 from group_db import load_db, save_db
@@ -47,7 +46,7 @@ class AppController:
         # --- NEW: Concurrency lock and database state ---
         self.zalo_lock = threading.Lock()
         self.group_db = load_db()
-        self.group_scan_queue = [] # A simple queue for which group to scan next
+        self.group_scan_queue = Queue()
         
         # --- NEW: State for image processing ---
         self.command_queue = Queue()
@@ -64,7 +63,6 @@ class AppController:
         self.cargo_cache = {}
         self.avail_list = set()
         self.paid_list = set()
-        self.last_group_scrape_time = 0
         
         # --- NEW: State for proactive workflow ---
         self.proactive_flight_list = [] # Stores list of dicts from FlightListWorker
@@ -270,117 +268,67 @@ class AppController:
                 logger.error(f"Error in cache cleanup loop: {e}")
                 time.sleep(60)
 
-    # --- NEW: Group identity and validation logic ---
-    def _calculate_similarity(self, set1, set2):
-        """Calculates the Jaccard similarity between two sets."""
-        if not set1 and not set2:
-            return 1.0
-        if not set1 or not set2:
-            return 0.0
-        intersection = len(set1.intersection(set2))
-        union = len(set1.union(set2))
-        return intersection / union
+    # --- Background threads for group management ---
 
-    def find_renamed_group(self, old_name: str) -> str | None:
-        """Tries to find a renamed group by comparing member lists."""
-        logger.warning(f"Attempting to find potentially renamed group for '{old_name}'...")
-        
-        # Find the old group's data in our DB
-        old_group_id = None
-        for gid, data in self.group_db.items():
-            if data['current_name'] == old_name:
-                old_group_id = gid
-                break
-        
-        if not old_group_id:
-            logger.error(f"No database entry found for '{old_name}'. Cannot validate rename.")
-            return None
-            
-        last_known_members = set(self.group_db[old_group_id]['last_known_members'])
-        if not last_known_members:
-            logger.error(f"No members recorded for '{old_name}'. Cannot validate rename.")
-            return None
-
-        # Compare against all current groups in the DB
-        best_match_name = None
-        highest_similarity = 0.75 # Must be at least 75% similar
-
-        for gid, data in self.group_db.items():
-            # Skip comparing a group to itself
-            if gid == old_group_id:
-                continue
-
-            current_members = set(data['last_known_members'])
-            similarity = self._calculate_similarity(last_known_members, current_members)
-            
-            if similarity > highest_similarity:
-                highest_similarity = similarity
-                best_match_name = data['current_name']
-        
-        if best_match_name:
-            logger.info(f"Found a likely match for '{old_name}'! New name: '{best_match_name}' with {highest_similarity:.2f} similarity.")
-            # Update the DB to merge the old record into the new one
-            self.group_db[old_group_id]['current_name'] = best_match_name
-            save_db(self.group_db)
-            return best_match_name
-            
-        logger.warning(f"Could not find a suitable rename match for '{old_name}'.")
-        return None
-
-    # --- NEW: Background thread for scanning group members ---
-    def _group_scanner_loop(self):
-        """Periodically scrapes members from groups to keep the database updated."""
-        time.sleep(10) # Initial delay
-        logger.info("Group Member Scanner thread started.")
-        
+    def _group_list_loop(self):
+        """Periodically scrapes the community list for group names."""
+        time.sleep(5)
+        logger.info("Group List worker started.")
         while self.is_running:
             try:
-                # If the scan queue is empty, populate it with all known groups
-                if not self.group_scan_queue:
-                    # Sort for consistent, alphabetical order
-                    self.group_scan_queue = sorted(list(self.avail_list))
-
-                if not self.group_scan_queue:
-                    # Still no groups, wait a bit
-                    time.sleep(60)
-                    continue
-
-                # Get the next group to scan
-                group_to_scan = self.group_scan_queue.pop(0)
-
-                logger.info(f"[Scanner] Acquiring lock to scan group: '{group_to_scan}'")
                 with self.zalo_lock:
-                    self.zalo_manager.close_sidebar_if_open() # Cleanup first
-                    if self.zalo_manager._click_group(group_to_scan):
-                        if self.zalo_manager.click_group_members_icon():
-                            members = self.zalo_manager.scrape_group_members()
-                            if members:
-                                # Find if this group exists in DB or create a new entry
-                                group_id = None
-                                for gid, data in self.group_db.items():
-                                    if data['current_name'] == group_to_scan:
-                                        group_id = gid
-                                        break
-                                
-                                if not group_id: # New group, create ID
-                                    group_id = str(uuid.uuid4())
-                                
-                                # Update DB record
-                                self.group_db[group_id] = {
-                                    "current_name": group_to_scan,
-                                    "last_known_members": members,
-                                    "last_updated": datetime.now(timezone.utc).isoformat()
-                                }
-                                save_db(self.group_db)
-                        self.zalo_manager.close_sidebar_if_open()
-                logger.info(f"[Scanner] Released lock after scanning.")
-
-                # Wait for the configured interval before next scan
-                time.sleep(180) # 3 minutes between scans
-
+                    scraped = self.zalo_manager.scrape_group_list()
+                if scraped:
+                    new_set = set(scraped)
+                    added = new_set - self.avail_list
+                    if added:
+                        logger.info(f"Detected {len(added)} new/renamed groups: {list(added)}")
+                        for name in added:
+                            self.group_scan_queue.put(name)
+                    self.avail_list = new_set
+                time.sleep(15 * 60)
             except Exception as e:
-                logger.error(f"Error in group scanner loop: {e}", exc_info=True)
-                time.sleep(60) # Wait longer on error
+                logger.error(f"Error in group list loop: {e}", exc_info=True)
+                time.sleep(60)
+
+    def _group_validation_loop(self):
+        """Consumes groups from queue and records their invitation link."""
+        time.sleep(10)
+        logger.info("Group Validation thread started.")
+        while self.is_running:
+            try:
+                group_to_scan = self.group_scan_queue.get(timeout=5)
+            except Empty:
+                time.sleep(1)
+                continue
+            try:
+                logger.info(f"[Validator] Acquiring lock for '{group_to_scan}'")
+                with self.zalo_lock:
+                    self.zalo_manager.close_sidebar_if_open()
+                    if self.zalo_manager.open_group_via_list(group_to_scan):
+                        link = self.zalo_manager.get_invitation_link()
+                        if link:
+                            group_id = link.rstrip('/').split('/')[-1]
+                            record = self.group_db.get(group_id)
+                            old_name = record['current_name'] if record else None
+                            self.group_db[group_id] = {
+                                "current_name": group_to_scan,
+                                "invite_link": link,
+                                "last_updated": datetime.now(timezone.utc).isoformat(),
+                            }
+                            save_db(self.group_db)
+                            if old_name and old_name != group_to_scan:
+                                if old_name in self.paid_list:
+                                    self.paid_list.remove(old_name)
+                                    self.paid_list.add(group_to_scan)
+                                if old_name == self.user_settings.control_group:
+                                    self.user_settings.control_group = group_to_scan
+                                    save_user_settings(self.user_settings)
+                        self.zalo_manager.close_sidebar_if_open()
+                logger.info(f"[Validator] Finished processing '{group_to_scan}'")
+            except Exception as e:
+                logger.error(f"Error in group validation loop: {e}", exc_info=True)
+                time.sleep(30)
 
     def run(self):
         try:
@@ -390,7 +338,9 @@ class AppController:
             self.shutdown()
             return
         self.zalo_manager = ZaloManager(
-            self.zalo_driver, self.config.settings.get('zalo_action_delay', 1.5)
+            self.zalo_driver,
+            self.config.zalo_selectors,
+            self.config.settings.get('zalo_action_delay', 1.5),
         )
         if not self.zalo_manager.login_and_wait(): self.shutdown()
         
@@ -409,26 +359,18 @@ class AppController:
             daemon=True,
         )
         cache_cleanup_thread = threading.Thread(target=self._cache_cleanup_loop, name="CacheCleaner", daemon=True)
-        # --- NEW: Start the group scanner thread ---
-        group_scanner_thread = threading.Thread(target=self._group_scanner_loop, name="GroupScanner", daemon=True)
+        group_list_thread = threading.Thread(target=self._group_list_loop, name="GroupListWorker", daemon=True)
+        group_validator_thread = threading.Thread(target=self._group_validation_loop, name="GroupValidator", daemon=True)
         
         report_thread.start()
         proactive_thread.start()
         cache_cleanup_thread.start()
-        group_scanner_thread.start()
+        group_list_thread.start()
+        group_validator_thread.start()
         
         logger.info("Setup complete. Starting main monitoring loop...")
         while self.is_running:
             try:
-                # --- This block now feeds the scanner ---
-                if time.time() - self.last_group_scrape_time > 15 * 60:
-                    logger.info("Scraping Zalo sidebar to update available groups list...")
-                    with self.zalo_lock:
-                         scraped_groups = self.zalo_manager.scrape_all_groups()
-                    if scraped_groups:
-                        self.avail_list = set(scraped_groups)
-                    self.last_group_scrape_time = time.time()
-                
                 if time.time() - self.last_refresh_time > 4 * 3600:
                     logger.info("Performing periodic 4-hour refresh of Zalo page.")
                     self.zalo_manager.driver.refresh()
@@ -445,52 +387,32 @@ class AppController:
                 except Empty:
                     pass # No queued commands, proceed as normal
 
-                # --- MODIFIED: Main loop now uses the Zalo lock and rename validation ---
                 with self.zalo_lock:
+                    stay_group = self.user_settings.stay_group
+                    if stay_group:
+                        self.zalo_manager.navigate_to_group(stay_group)
+
                     unread_groups = self.zalo_manager.get_unread_group_names()
-                    
-                    # Validate that our monitored groups still exist
-                    current_paid_list = self.paid_list.copy()
-                    for group_name in current_paid_list:
-                        if group_name not in self.avail_list:
-                            new_name = self.find_renamed_group(group_name)
-                            if new_name:
-                                self.paid_list.remove(group_name)
-                                self.paid_list.add(new_name)
-                                logger.warning(f"Updated paid list: Replaced '{group_name}' with '{new_name}'.")
 
-                    if self.user_settings.control_group not in self.avail_list:
-                        new_name = self.find_renamed_group(self.user_settings.control_group)
-                        if new_name:
-                            self.user_settings.control_group = new_name
-                            save_user_settings(self.user_settings)
-                            logger.warning(
-                                f"Updated control group name to '{new_name}'."
-                            )
-
-                    # Process commands from unread groups
                     for group in unread_groups:
                         if group in groups_to_monitor:
                             if group not in self.last_check_times:
                                 self.last_check_times[group] = datetime.now() - timedelta(days=1)
-                            
+
                             new_messages = self.zalo_manager.read_new_messages(group, self.last_check_times[group])
                             if new_messages:
                                 self.last_check_times[group] = new_messages[-1]['timestamp']
                                 for msg in new_messages:
-                                    # If it's a text message, handle as a command
                                     if msg['type'] == 'text':
                                         self._handle_command(msg['content'], group)
-                                    # If it's an image and the feature is on, start the OCR worker
                                     elif msg['type'] == 'image' and self.image_processing_enabled:
                                         logger.info(f"Image detected in '{group}'. Starting Gemini-powered OCR worker.")
-                                        worker = OCRWorker(msg['content'], group, self.google_api_key, 
+                                        worker = OCRWorker(msg['content'], group, self.google_api_key,
                                                         self.command_queue, self.report_queue)
-                                        # This worker is short-lived, no need to track in active_workers
                                         worker.start()
-                    
-                    stay_group = self.user_settings.stay_group
-                    if stay_group: self.zalo_manager.navigate_to_group(stay_group)
+
+                    if stay_group:
+                        self.zalo_manager.navigate_to_group(stay_group)
 
                 time.sleep(self.config.settings.get('manager_loop_delay', 5))
 

--- a/SEbased/worker_manager.py
+++ b/SEbased/worker_manager.py
@@ -34,11 +34,13 @@ def process_report_queue(controller) -> None:
             elif task_id in controller.flight_subscriptions:
                 subscribers = controller.flight_subscriptions.get(task_id, set())
                 for group in subscribers:
-                    controller.zalo_manager.send_message(group, status)
+                    with controller.zalo_lock:
+                        controller.zalo_manager.send_message(group, status)
             else:
-                controller.zalo_manager.send_message(
-                    report["reporting_group"], status
-                )
+                with controller.zalo_lock:
+                    controller.zalo_manager.send_message(
+                        report["reporting_group"], status
+                    )
 
             if is_final:
                 with controller.worker_lock:

--- a/SEbased/zalo.py
+++ b/SEbased/zalo.py
@@ -65,6 +65,16 @@ class ZaloManager:
         """Finds a group by its title in the conversation list and clicks it."""
         logger.debug(f"Attempting to click group: '{group_title}'")
         try:
+            # Ensure the conversation sidebar is visible
+            try:
+                msg_icon = WebDriverWait(self.driver, 5).until(
+                    EC.element_to_be_clickable((By.CSS_SELECTOR, self.selectors["message_icon"]))
+                )
+                msg_icon.click()
+                time.sleep(self.action_delay)
+            except Exception as e:
+                logger.debug(f"Message icon click skipped or failed: {e}")
+
             # Using XPath to find an element by its exact text content
             group_xpath = f"//*[normalize-space(text())='{group_title}']/ancestor::div[contains(@class, 'conv-item')][1]"
             group_element = WebDriverWait(self.driver, 10).until(
@@ -278,100 +288,96 @@ class ZaloManager:
         Navigates to a specific group without reading or sending messages.
         Used to reset the view to the stay/fallback group.
         """
+        try:
+            msg_icon = WebDriverWait(self.driver, 5).until(
+                EC.element_to_be_clickable((By.CSS_SELECTOR, self.selectors["message_icon"]))
+            )
+            msg_icon.click()
+            time.sleep(self.action_delay)
+        except Exception as e:
+            logger.debug(f"Could not ensure message sidebar: {e}")
+
         if self.get_active_group_name() != group_title:
             logger.info(f"Returning to fallback group: '{group_title}'")
             self._click_group(group_title)
             
-# In zalo.py, replace the existing scrape_all_groups function with this one:
-    def scrape_all_groups(self):
-        """
-        Scrapes all group titles from the conversation sidebar, scrolling down to find all of them.
-        """
-        all_groups = set()
-        scroll_attempts = 0
-        max_scrolls = 20 # Safety break to prevent infinite loops
-
+    def _open_group_list(self) -> bool:
+        """Opens the contacts/community list that contains all groups."""
         try:
-            # Find the scrollable container for the conversation list
-            scroll_container_selector = "div#conversationListId"
-            scroll_container = self.driver.find_element(By.CSS_SELECTOR, scroll_container_selector)
-            
-            while scroll_attempts < max_scrolls:
-                previous_group_count = len(all_groups)
-
-                # Scrape all currently visible groups
-                group_elements = self.driver.find_elements(By.CSS_SELECTOR, self.selectors["group_title_in_item"])
-                for elem in group_elements:
-                    try:
-                        name = elem.text.strip()
-                        if name:
-                            all_groups.add(name)
-                    except Exception:
-                        continue # Ignore stale elements
-
-                # Scroll the container to the bottom
-                self.driver.execute_script("arguments[0].scrollTop = arguments[0].scrollHeight", scroll_container)
-                
-                # Wait for any new groups to load
-                time.sleep(1.5)
-
-                # If the number of groups hasn't changed after scrolling and waiting, we're at the bottom
-                if len(all_groups) == previous_group_count:
-                    logger.info(f"Scraping complete. Found {len(all_groups)} unique groups after {scroll_attempts + 1} scrolls.")
-                    break
-                
-                scroll_attempts += 1
-            
-            if scroll_attempts >= max_scrolls:
-                logger.warning(f"Reached max scrolls ({max_scrolls}). Returning {len(all_groups)} found groups.")
-
-            return list(all_groups)
-
-        except Exception as e:
-            logger.error(f"Could not scrape group list with scrolling: {e}")
-            # Return whatever was found, even if the process failed midway
-            return list(all_groups)
-
-    def click_group_members_icon(self) -> bool:
-        """Clicks the icon in the header that opens the group member sidebar."""
-        try:
-            # This selector targets the clickable area showing member count
-            member_icon_selector = "div.subtitle__groupmember__content"
-            wait = WebDriverWait(self.driver, 10)
-            member_icon = wait.until(
-                EC.element_to_be_clickable((By.CSS_SELECTOR, member_icon_selector))
+            msg_icon = WebDriverWait(self.driver, 10).until(
+                EC.element_to_be_clickable((By.CSS_SELECTOR, self.selectors["message_icon"]))
             )
-            member_icon.click()
-            # Wait for the sidebar to become visible
-            wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, "div.chat-box-member")))
-            logger.info("Successfully opened group member sidebar.")
+            msg_icon.click()
+            time.sleep(self.action_delay)
+
+            contact_icon = WebDriverWait(self.driver, 10).until(
+                EC.element_to_be_clickable((By.CSS_SELECTOR, self.selectors["contact_icon"]))
+            )
+            contact_icon.click()
+            time.sleep(self.action_delay)
+
+            community_icon = WebDriverWait(self.driver, 10).until(
+                EC.element_to_be_clickable((By.CSS_SELECTOR, self.selectors["community_icon"]))
+            )
+            community_icon.click()
+            time.sleep(self.action_delay)
             return True
-        except TimeoutException:
-            logger.warning("Could not find or click the group member icon.")
+        except Exception as e:
+            logger.warning(f"Could not open group list: {e}")
             return False
 
-    def scrape_group_members(self) -> list[str]:
-        """Scrapes all member names from the visible member sidebar. Assumes sidebar is already open."""
-        members = []
+    def scrape_group_list(self) -> list[str]:
+        """Scrapes all group names from the community list."""
+        if not self._open_group_list():
+            return []
+        group_names = []
         try:
             wait = WebDriverWait(self.driver, 15)
-            # This selector targets each member item in the list
-            member_elements_selector = "div[data-id='div_MemList_MemItem']"
-            member_elements = wait.until(
-                EC.presence_of_all_elements_located((By.CSS_SELECTOR, member_elements_selector))
+            group_elements = wait.until(
+                EC.presence_of_all_elements_located((By.CSS_SELECTOR, self.selectors["group_list_items"]))
             )
-            
-            for elem in member_elements:
-                # The member's full name is reliably in the 'title' attribute
-                name = elem.get_attribute('title')
+            for elem in group_elements:
+                name = elem.text.strip()
                 if name:
-                    members.append(name.strip())
-            
-            logger.info(f"Scraped {len(members)} members.")
-            return members
-        except TimeoutException:
-            logger.error("Timed out waiting for member list to appear in sidebar.")
-            return []
+                    group_names.append(name)
+            logger.info(f"Scraped {len(group_names)} groups from community list.")
+        except Exception as e:
+            logger.error(f"Could not scrape group list: {e}")
+        return group_names
+
+    def open_group_via_list(self, group_title: str) -> bool:
+        """From the community list, open a group's chat window."""
+        if not self._open_group_list():
+            return False
+        try:
+            group_xpath = f"//span[@class='name' and normalize-space(text())='{group_title}']"
+            group_elem = WebDriverWait(self.driver, 10).until(
+                EC.element_to_be_clickable((By.XPATH, group_xpath))
+            )
+            group_elem.click()
+            WebDriverWait(self.driver, 5).until(
+                EC.text_to_be_present_in_element((By.CSS_SELECTOR, self.selectors["header_title_active_group"]), group_title)
+            )
+            return True
+        except Exception as e:
+            logger.warning(f"Failed to open group '{group_title}' via list: {e}")
+            return False
+
+    def get_invitation_link(self) -> str | None:
+        """Opens the group info and returns the invitation link."""
+        try:
+            avatar = WebDriverWait(self.driver, 10).until(
+                EC.element_to_be_clickable((By.CSS_SELECTOR, self.selectors["group_avatar"]))
+            )
+            avatar.click()
+            link_elem = WebDriverWait(self.driver, 10).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, self.selectors["invitation_link"]))
+            )
+            link = link_elem.text.strip()
+            return link
+        except Exception as e:
+            logger.warning(f"Could not scrape invitation link: {e}")
+            return None
 
     def close_sidebar_if_open(self):
         """Closes the right sidebar by sending the ESCAPE key to the chat input."""


### PR DESCRIPTION
## Summary
- add CSS selectors for contact/community icons, group avatars, and invitation links
- scrape the community group list and invitation links instead of member lists
- run background threads to update available groups and validate them via invitation links
- ensure Zalo sidebar is visible before switching to groups and lock report queue sends

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689977159ef8832ab724a3281cc403cb